### PR TITLE
Schema improvements and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,22 @@ sh.exe.stackdump
 .sass-cache/*
 node_modules/*
 
+###################
+# Python venvs     #
+###################
+.venv/
+venv/
+ENV/
+
+###################
+# Python artifacts #
+###################
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.egg-info/
+
 #############################
 # Override parent gitignore #
 #############################

--- a/tools/law-rdf-validator/README.md
+++ b/tools/law-rdf-validator/README.md
@@ -1,0 +1,54 @@
+# law-rdf-validator
+
+Deterministic SHACL validation for OLL `law-rdf` datasets.
+
+This tool validates your RDF data against the SHACL shapes shipped in this repo:
+
+- Shapes: `us/ngo/oll/_ontology/v0.1/law-rdf.shacl.ttl`
+- Ontology (optional for inference): `us/ngo/oll/_ontology/v0.1/ontology.owl`
+
+## Setup (uv)
+
+From the repo root:
+
+```bash
+cd tools/law-rdf-validator
+uv sync
+```
+
+## Validate a Dataset Folder
+
+Example (Mohican archive):
+
+```bash
+cd tools/law-rdf-validator
+uv run law-rdf-validate ~/oll/archive/mohicanlaw/law-rdf
+```
+
+## Common Options
+
+- Write the full report to a file:
+
+```bash
+uv run law-rdf-validate ~/oll/archive/mohicanlaw/law-rdf --report /tmp/law-rdf-shacl-report.txt
+```
+
+- Validate a single RDF/XML file:
+
+```bash
+uv run law-rdf-validate ~/oll/archive/mohicanlaw/law-rdf/index.rdf
+```
+
+- Override shapes/ontology paths:
+
+```bash
+uv run law-rdf-validate ~/oll/archive/mohicanlaw/law-rdf \
+  --shapes ../../us/ngo/oll/_ontology/v0.1/law-rdf.shacl.ttl \
+  --ontology ../../us/ngo/oll/_ontology/v0.1/ontology.owl
+```
+
+## Exit Codes
+
+- `0`: conforms
+- `1`: does not conform (violations exist)
+- `2`: usage/config/parse error

--- a/tools/law-rdf-validator/law_rdf_validator/__init__.py
+++ b/tools/law-rdf-validator/law_rdf_validator/__init__.py
@@ -1,0 +1,1 @@
+"""Validation utilities for OLL law-rdf datasets."""

--- a/tools/law-rdf-validator/law_rdf_validator/cli.py
+++ b/tools/law-rdf-validator/law_rdf_validator/cli.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from rdflib import Graph
+from pyshacl import validate
+
+
+def _find_repo_root(start: Path) -> Path | None:
+    """Walk upwards until we find the ontology+shapes paths."""
+    want_shapes = Path("us/ngo/oll/_ontology/v0.1/law-rdf.shacl.ttl")
+    want_owl = Path("us/ngo/oll/_ontology/v0.1/ontology.owl")
+    cur = start
+    while True:
+        if (cur / want_shapes).exists() and (cur / want_owl).exists():
+            return cur
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+
+
+def _load_data_graph(
+    data_path: Path, *, format_hint: str | None = None
+) -> tuple[Graph, int]:
+    g = Graph()
+    parse_errors = 0
+
+    if data_path.is_dir():
+        rdf_files = sorted(data_path.rglob("*.rdf"))
+        if not rdf_files:
+            raise ValueError(f"No .rdf files found under {data_path}")
+        for f in rdf_files:
+            try:
+                g.parse(f.as_posix(), format=format_hint)
+            except Exception as e:
+                parse_errors += 1
+                print(f"[PARSE ERROR] {f}: {e}", file=sys.stderr)
+    else:
+        g.parse(data_path.as_posix(), format=format_hint)
+
+    return g, parse_errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate a law-rdf dataset against SHACL shapes"
+    )
+    parser.add_argument("data", help="Path to law-rdf folder or a single RDF file")
+    parser.add_argument(
+        "--shapes",
+        help="Path to SHACL shapes TTL (defaults to repo's law-rdf.shacl.ttl)",
+        default=None,
+    )
+    parser.add_argument(
+        "--ontology",
+        help="Path to ontology OWL (optional; used as ont_graph for inference)",
+        default=None,
+    )
+    parser.add_argument(
+        "--inference",
+        choices=["none", "rdfs"],
+        default="rdfs",
+        help="Inference level for SHACL validation",
+    )
+    parser.add_argument(
+        "--report",
+        help="Write text report to this path",
+        default=None,
+    )
+    parser.add_argument(
+        "--format",
+        help="Optional rdflib parse format hint (e.g., 'xml')",
+        default=None,
+    )
+
+    args = parser.parse_args(argv)
+    data_path = Path(args.data).expanduser().resolve()
+    if not data_path.exists():
+        print(f"Data path not found: {data_path}", file=sys.stderr)
+        return 2
+
+    # Resolve defaults from repo root
+    repo_root = _find_repo_root(Path(__file__).resolve())
+    if repo_root is None:
+        repo_root = _find_repo_root(Path.cwd())
+
+    shapes_path: Path | None
+    ontology_path: Path | None
+
+    if args.shapes is None:
+        if repo_root is None:
+            print("Unable to locate repo root; provide --shapes", file=sys.stderr)
+            return 2
+        shapes_path = repo_root / "us/ngo/oll/_ontology/v0.1/law-rdf.shacl.ttl"
+    else:
+        shapes_path = Path(args.shapes).expanduser().resolve()
+
+    if args.ontology is None:
+        ontology_path = None
+        if repo_root is not None:
+            candidate = repo_root / "us/ngo/oll/_ontology/v0.1/ontology.owl"
+            if candidate.exists():
+                ontology_path = candidate
+    else:
+        ontology_path = Path(args.ontology).expanduser().resolve()
+
+    if not shapes_path.exists():
+        print(f"Shapes file not found: {shapes_path}", file=sys.stderr)
+        return 2
+
+    try:
+        data_g, parse_errors = _load_data_graph(data_path, format_hint=args.format)
+    except Exception as e:
+        print(str(e), file=sys.stderr)
+        return 2
+
+    shapes_g = Graph().parse(shapes_path.as_posix(), format="turtle")
+    ont_g = None
+    if ontology_path is not None and ontology_path.exists():
+        try:
+            ont_g = Graph().parse(ontology_path.as_posix())
+        except Exception as e:
+            print(f"[ONTOLOGY PARSE ERROR] {ontology_path}: {e}", file=sys.stderr)
+            return 2
+
+    conforms, _, report_text = validate(
+        data_graph=data_g,
+        shacl_graph=shapes_g,
+        ont_graph=ont_g,
+        inference=None if args.inference == "none" else args.inference,
+        abort_on_first=False,
+        allow_infos=True,
+        allow_warnings=True,
+        meta_shacl=False,
+        advanced=True,
+        js=False,
+        debug=False,
+    )
+
+    if args.report:
+        report_path = Path(args.report).expanduser().resolve()
+        report_path.write_text(report_text, encoding="utf-8")
+        print(f"Report: {report_path}")
+
+    print(f"Conforms: {conforms}")
+    if parse_errors:
+        print(f"Parse errors: {parse_errors}")
+
+    if conforms:
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/law-rdf-validator/pyproject.toml
+++ b/tools/law-rdf-validator/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "law-rdf-validator"
+version = "0.1.0"
+description = "Validate OLL law-rdf datasets with SHACL shapes"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "pyshacl>=0.31.0,<0.32.0",
+  "rdflib>=7.6.0,<8",
+]
+
+[project.scripts]
+law-rdf-validate = "law_rdf_validator.cli:main"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/tools/law-rdf-validator/uv.lock
+++ b/tools/law-rdf-validator/uv.lock
@@ -1,0 +1,146 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+
+[[package]]
+name = "html5rdf"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/55/1b839c43f5ed8207e17a9a02d8b395179520b8b4f00c00a41e113bc205ca/html5rdf-1.2.1.tar.gz", hash = "sha256:ace9b420ce52995bb4f05e7425eedf19e433c981dfe7a831ab391e2fa2e1a195", size = 287899, upload-time = "2024-10-30T05:06:56.384Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/c9/f6e1e8567660bc5b0aba281f2b0017b2a7665fcad6bf3ed67286a0c72cd4/html5rdf-1.2.1-py2.py3-none-any.whl", hash = "sha256:1f519121bc366af3e485310dc8041d2e86e5173c1a320fac3dc9d2604069b83e", size = 109765, upload-time = "2024-10-30T05:06:52.507Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
+name = "law-rdf-validator"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pyshacl" },
+    { name = "rdflib" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pyshacl", specifier = ">=0.31.0,<0.32.0" },
+    { name = "rdflib", specifier = ">=7.6.0,<8" },
+]
+
+[[package]]
+name = "owlrl"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "rdflib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/fc/ce12482d096d65fff01af58f555a6f25e9dbf416fad5d99f91eaab0e11ca/owlrl-7.1.4.tar.gz", hash = "sha256:60bd4067e346b9111f0a2924565afe97ac6595b98b2bbe953928b5113971daf7", size = 44420, upload-time = "2025-07-29T00:17:27.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/78/f857ff1a7207e967dc5e8414bbcc15e0aa5cf45f693b1d2ebe2afb3eb1ce/owlrl-7.1.4-py3-none-any.whl", hash = "sha256:e78b46020169783345636da93a467d318f18700c483184dd15e885850cf64775", size = 51981, upload-time = "2025-07-29T00:17:26.229Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "prettytable"
+version = "3.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyshacl"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "owlrl" },
+    { name = "packaging" },
+    { name = "prettytable" },
+    { name = "rdflib", extra = ["html"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/2d/8eaada41b9b57c028a54494688e45cfeefd6756098a6bf1bfa2dd9470cdf/pyshacl-0.31.0.tar.gz", hash = "sha256:327950875a5bb0d1a15c246a8a272b2dbf6bc9b96e28cfa8fdbfa4d73aadc0ba", size = 1406151, upload-time = "2026-01-16T06:34:06.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/3b/ebd7c9595fcdf176555aaf2fd2254f4d890658334ca3556b611e579f8294/pyshacl-0.31.0-py3-none-any.whl", hash = "sha256:5cae2184401d956b67deebb00e3c78ab7052784741a730e52e309e33c8a0b9a5", size = 1297210, upload-time = "2026-01-16T06:34:03.679Z" },
+]
+
+[[package]]
+name = "rdflib"
+version = "7.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "isodate", marker = "python_full_version < '3.11'" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f5/18bb77b7af9526add0c727a3b2048959847dc5fb030913e2918bf384fec3/rdflib-7.6.0.tar.gz", hash = "sha256:6c831288d5e4a5a7ece85d0ccde9877d512a3d0f02d7c06455d00d6d0ea379df", size = 4943826, upload-time = "2026-02-13T07:15:55.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/c2/6604a71269e0c1bd75656d5a001432d16f2cc5b8c057140ec797155c295e/rdflib-7.6.0-py3-none-any.whl", hash = "sha256:30c0a3ebf4c0e09215f066be7246794b6492e054e782d7ac2a34c9f70a15e0dd", size = 615416, upload-time = "2026-02-13T07:15:46.487Z" },
+]
+
+[package.optional-dependencies]
+html = [
+    { name = "html5rdf" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+]

--- a/us/ngo/oll/_ontology/v0.1/README.md
+++ b/us/ngo/oll/_ontology/v0.1/README.md
@@ -1,0 +1,16 @@
+# OLL Ontology v0.1
+
+This directory contains:
+
+- Ontology: `us/ngo/oll/_ontology/v0.1/ontology.owl`
+- SHACL shapes for deterministic dataset validation: `us/ngo/oll/_ontology/v0.1/law-rdf.shacl.ttl`
+
+## Validate a law-rdf checkout
+
+Use the validator tool shipped in this repo:
+
+```bash
+cd tools/law-rdf-validator
+uv sync
+uv run law-rdf-validate ~/oll/archive/mohicanlaw/law-rdf --report /tmp/law-rdf-shacl-report.txt
+```

--- a/us/ngo/oll/_ontology/v0.1/law-rdf.shacl.ttl
+++ b/us/ngo/oll/_ontology/v0.1/law-rdf.shacl.ttl
@@ -80,11 +80,6 @@ ollsh:DocumentVersionShape
     sh:nodeKind sh:Literal ;
   ] ;
   sh:property [
-    sh:path oll:url ;
-    sh:minCount 1 ;
-    sh:nodeKind sh:Literal ;
-  ] ;
-  sh:property [
     sh:path oll:hasChanges ;
     sh:nodeKind sh:IRI ;
     sh:class rdf:Bag ;

--- a/us/ngo/oll/_ontology/v0.1/law-rdf.shacl.ttl
+++ b/us/ngo/oll/_ontology/v0.1/law-rdf.shacl.ttl
@@ -1,0 +1,185 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix oll: <https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#> .
+@prefix ollsh: <https://open.law/us/ngo/oll/_ontology/v0.1/shapes#> .
+
+ollsh:DateLiteralShape
+  a sh:NodeShape ;
+  sh:or (
+    [ sh:datatype xsd:date ]
+    [ sh:datatype xsd:string ; sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" ]
+  ) .
+
+ollsh:DocumentVersionShape
+  a sh:NodeShape ;
+  sh:targetClass oll:DocumentVersion ;
+  sh:property [
+    sh:path dcterms:available ;
+    sh:minCount 1 ;
+    sh:node ollsh:DateLiteralShape ;
+    sh:message "DocumentVersion must have dcterms:available as YYYY-MM-DD." ;
+  ] ;
+  sh:property [
+    sh:path dcterms:title ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:Literal ;
+  ] ;
+  sh:property [
+    sh:path dcterms:creator ;
+    sh:nodeKind sh:Literal ;
+  ] ;
+  sh:property [
+    sh:path dcterms:rights ;
+    sh:nodeKind sh:Literal ;
+  ] ;
+  sh:property [
+    sh:path dcterms:isVersionOf ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:IRI ;
+  ] ;
+  sh:property [
+    sh:path oll:isPartOfPublication ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:IRI ;
+    sh:class oll:Publication ;
+  ] ;
+  sh:property [
+    sh:path oll:codifiedDate ;
+    sh:minCount 1 ;
+    sh:node ollsh:DateLiteralShape ;
+    sh:message "DocumentVersion must have oll:codifiedDate as YYYY-MM-DD." ;
+  ] ;
+  sh:property [
+    sh:path oll:dateEffective ;
+    sh:maxCount 1 ;
+    sh:node ollsh:DateLiteralShape ;
+  ] ;
+  sh:property [
+    sh:path oll:dateAdopted ;
+    sh:maxCount 1 ;
+    sh:node ollsh:DateLiteralShape ;
+  ] ;
+  sh:property [
+    sh:path oll:dateCurrentThrough ;
+    sh:maxCount 1 ;
+    sh:node ollsh:DateLiteralShape ;
+  ] ;
+  sh:property [
+    sh:path oll:number ;
+    sh:nodeKind sh:Literal ;
+  ] ;
+  sh:property [
+    sh:path oll:docId ;
+    sh:nodeKind sh:Literal ;
+  ] ;
+  sh:property [
+    sh:path oll:buildReason ;
+    sh:nodeKind sh:Literal ;
+  ] ;
+  sh:property [
+    sh:path oll:url ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:Literal ;
+  ] ;
+  sh:property [
+    sh:path oll:hasChanges ;
+    sh:nodeKind sh:IRI ;
+    sh:class rdf:Bag ;
+  ] ;
+  sh:property [
+    sh:path dcterms:references ;
+    sh:nodeKind sh:IRI ;
+    sh:class oll:SourceDocument ;
+  ] ;
+  sh:property [
+    sh:path dcterms:hasFormat ;
+    sh:nodeKind sh:IRI ;
+    sh:class oll:SourceDocument ;
+  ] ;
+  sh:property [
+    sh:path dcterms:tableOfContents ;
+    sh:nodeKind sh:Literal ;
+  ] .
+
+ollsh:PublicationShape
+  a sh:NodeShape ;
+  sh:targetClass oll:Publication ;
+  sh:property [
+    sh:path dcterms:available ;
+    sh:minCount 1 ;
+    sh:node ollsh:DateLiteralShape ;
+  ] ;
+  sh:property [
+    sh:path dcterms:creator ;
+    sh:nodeKind sh:Literal ;
+  ] ;
+  sh:property [
+    sh:path oll:hasDocument ;
+    sh:nodeKind sh:IRI ;
+  ] ;
+  sh:property [
+    sh:path dcterms:isPartOf ;
+    sh:nodeKind sh:IRI ;
+  ] .
+
+ollsh:SourceDocumentShape
+  a sh:NodeShape ;
+  sh:targetClass oll:SourceDocument ;
+  sh:property [
+    sh:path dcterms:title ;
+    sh:nodeKind sh:Literal ;
+  ] ;
+  sh:property [
+    sh:path dcterms:creator ;
+    sh:nodeKind sh:Literal ;
+  ] ;
+  sh:property [
+    sh:path dcterms:date ;
+    sh:node ollsh:DateLiteralShape ;
+  ] ;
+  sh:property [
+    sh:path dcterms:rights ;
+    sh:nodeKind sh:Literal ;
+  ] ;
+  sh:property [
+    sh:path oll:url ;
+    sh:nodeKind sh:Literal ;
+  ] .
+
+ollsh:ChangeBagShape
+  a sh:NodeShape ;
+  sh:targetClass rdf:Bag ;
+  sh:property [
+    sh:path [ sh:inversePath rdf:type ] ;
+    sh:nodeKind sh:IRI ;
+    sh:severity sh:Info ;
+  ] .
+
+ollsh:NodeWithPtagShape
+  a sh:NodeShape ;
+  sh:targetSubjectsOf oll:ptag ;
+  sh:property [
+    sh:path oll:url ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:Literal ;
+  ] ;
+  sh:property [
+    sh:path oll:ptag ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:Literal ;
+  ] ;
+  sh:property [
+    sh:path oll:cite ;
+    sh:nodeKind sh:Literal ;
+  ] ;
+  sh:property [
+    sh:path oll:documentMaterializedPath ;
+    sh:nodeKind sh:Literal ;
+  ] ;
+  sh:property [
+    sh:path oll:status ;
+    sh:nodeKind sh:Literal ;
+  ] .

--- a/us/ngo/oll/_ontology/v0.1/ontology.owl
+++ b/us/ngo/oll/_ontology/v0.1/ontology.owl
@@ -120,6 +120,8 @@
 
     <owl:ObjectProperty rdf:about="http://purl.org/dc/terms/hasFormat">
         <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/relation"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
+        <rdfs:range rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
         <rdfs:label xml:lang="en">Has Format</rdfs:label>
         <rdfs:comment xml:lang="en">Use when the cited resource is substantially the same content in a different format (e.g., an HTML page and a PDF rendering of the same document text). If uncertain whether the cited resource is truly an alternate format of the same content, prefer dcterms:references.</rdfs:comment>
         <skos:definition xml:lang="en">A related resource that is substantially the same content presented in another format.</skos:definition>
@@ -552,6 +554,7 @@
     <!-- http://purl.org/dc/terms/creator -->
 
     <owl:DatatypeProperty rdf:about="http://purl.org/dc/terms/creator">
+        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/creator"/>
         <rdfs:label xml:lang="en">Creator</rdfs:label>
         <rdfs:comment xml:lang="en">If modeled as a literal in data: the creator name/label (often the jurisdiction/governing body). Prefer using the object property form of dcterms:creator when you can identify the creator by IRI/URL.</rdfs:comment>
     </owl:DatatypeProperty>
@@ -763,6 +766,7 @@
         <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/description"/>
         <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Code"/>
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:comment xml:lang="en">Free-text table of contents / outline as emitted by the build pipeline. In law-rdf this may appear on codes and constitutions.</rdfs:comment>
     </owl:DatatypeProperty>
     
 

--- a/us/ngo/oll/_ontology/v0.1/ontology.owl
+++ b/us/ngo/oll/_ontology/v0.1/ontology.owl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#"
-     xml:base="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl"
+<rdf:RDF xmlns="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#"
+     xml:base="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:oll="http://open.law/ontologies/oll.owl#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -11,7 +11,7 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:skos="http://www.w3.org/2004/02/skos/core#"
      xmlns:dcterms="http://purl.org/dc/terms/">
-    <owl:Ontology rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#">
+    <owl:Ontology rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#">
         <rdfs:comment xml:lang="en">Open Law Library Ontology contains built-in classes and properties that put together the basis of legal entities and relations between them.</rdfs:comment>
         <rdfs:comment xml:lang="en">RDF usage note: rdf:about SHOULD identify the described resource's canonical URL (e.g., the HTML or PDF being described), not the URL of the RDF serialization describing it.</rdfs:comment>
         <rdfs:label xml:lang="en">Open Law Library Ontology</rdfs:label>
@@ -71,15 +71,15 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
-        <rdfs:range rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
+        <rdfs:range rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
     </owl:ObjectProperty>
     
 
@@ -99,8 +99,8 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -201,13 +201,13 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Charter"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Constitution"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Charter"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Constitution"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
-        <rdfs:range rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
+        <rdfs:range rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
         <rdfs:label xml:lang="en">References</rdfs:label>
         <rdfs:comment xml:lang="en">Use when the cited resource is related/supporting material or otherwise referenced context that is not merely the same content in another format. If the cited resource is instead the same content in another format, use dcterms:hasFormat.</rdfs:comment>
         <skos:definition xml:lang="en">A related resource that is cited, referred to, or otherwise pointed to as relevant context.</skos:definition>
@@ -248,96 +248,96 @@
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasDocument -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasDocument -->
 
-    <owl:ObjectProperty rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasDocument">
+    <owl:ObjectProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasDocument">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
-        <rdfs:range rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
+        <rdfs:range rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
         <rdfs:label xml:lang="en">Has Document</rdfs:label>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasDocumentPart -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasDocumentPart -->
 
-    <owl:ObjectProperty rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasDocumentPart">
+    <owl:ObjectProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasDocumentPart">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
-        <rdfs:range rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+        <rdfs:range rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart"/>
         <rdfs:label xml:lang="en">Has Document Part</rdfs:label>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasDocumentVersion -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasDocumentVersion -->
 
-    <owl:ObjectProperty rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasDocumentVersion">
+    <owl:ObjectProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasDocumentVersion">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
-        <rdfs:range rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+        <rdfs:range rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
         <rdfs:label xml:lang="en">Has Document Version</rdfs:label>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasLatestPublication -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasLatestPublication -->
 
-    <owl:ObjectProperty rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasLatestPublication">
+    <owl:ObjectProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasLatestPublication">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
-        <rdfs:range rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
+        <rdfs:range rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
         <rdfs:label xml:lang="en">Has Latest Publication</rdfs:label>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasLawLibrary -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasLawLibrary -->
 
-    <owl:ObjectProperty rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasLawLibrary">
+    <owl:ObjectProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasLawLibrary">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
-        <rdfs:range rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
+        <rdfs:range rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
         <rdfs:label xml:lang="en">Has Law Library</rdfs:label>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasPublication -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasPublication -->
 
-    <owl:ObjectProperty rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasPublication">
+    <owl:ObjectProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasPublication">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
-        <rdfs:range rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
+        <rdfs:range rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
         <rdfs:label xml:lang="en">Has Publication</rdfs:label>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#isPartOfPublication -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#isPartOfPublication -->
 
-    <owl:ObjectProperty rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#isPartOfPublication">
+    <owl:ObjectProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#isPartOfPublication">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
-        <rdfs:range rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
+        <rdfs:range rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
         <rdfs:label xml:lang="en">Is Part Of Publication</rdfs:label>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#lastCodifiedDocument -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#lastCodifiedDocument -->
 
-    <owl:ObjectProperty rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#lastCodifiedDocument">
+    <owl:ObjectProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#lastCodifiedDocument">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
-        <rdfs:range rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
+        <rdfs:range rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
         <rdfs:label xml:lang="en">Last Codified Document</rdfs:label>
         <rdfs:comment xml:lang="en">Points to the document that last codified/modified this DocumentVersion; typically sourced from XML /document/recency/doc. In RDF instances, the object IRI should identify the cited HTML/PDF resource, not an RDF description document.</rdfs:comment>
     </owl:ObjectProperty>
@@ -431,11 +431,11 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -458,11 +458,11 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -508,8 +508,8 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -756,7 +756,7 @@
 
     <owl:DatatypeProperty rdf:about="http://purl.org/dc/terms/tableOfContents">
         <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/description"/>
-        <rdfs:domain rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Code"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Code"/>
         <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"/>
     </owl:DatatypeProperty>
     
@@ -788,11 +788,11 @@
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#dateAdopted -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#dateAdopted -->
 
-    <owl:DatatypeProperty rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#dateAdopted">
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#dateAdopted">
         <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/date"/>
-        <rdfs:domain rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#date"/>
         <rdfs:label xml:lang="en">Date Adopted</rdfs:label>
         <rdfs:comment xml:lang="en">Typically sourced from XML /document/meta/history/adopted for resolutions.</rdfs:comment>
@@ -800,11 +800,11 @@
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#dateCurrentThrough -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#dateCurrentThrough -->
 
-    <owl:DatatypeProperty rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#dateCurrentThrough">
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#dateCurrentThrough">
         <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/date"/>
-        <rdfs:domain rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#date"/>
         <rdfs:label xml:lang="en">Date Current Through</rdfs:label>
         <rdfs:comment xml:lang="en">Applies primarily to codified codes (and other codified materials): the date (as of the codified date) that the document was last modified by a law; typically sourced from XML /document/recency/@through.</rdfs:comment>
@@ -812,22 +812,22 @@
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#dateEffective -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#dateEffective -->
 
-    <owl:DatatypeProperty rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#dateEffective">
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#dateEffective">
         <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/date"/>
-        <rdfs:domain rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#date"/>
         <rdfs:comment xml:lang="en">An effective date or as of date is the date upon which something is considered to take effect, which may be a past, present or future date.</rdfs:comment>
         <rdfs:comment xml:lang="en">Applicability varies by document type and available source data. For some Code items, an effective date may be unknown/unknowable; in those cases publishers may omit this property or provide a sentinel/placeholder value in their source systems.</rdfs:comment>
         <rdfs:label xml:lang="en">Date Effective</rdfs:label>
     </owl:DatatypeProperty>
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#history -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#history -->
 
-    <owl:DatatypeProperty rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#history">
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#history">
         <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/description"/>
-        <rdfs:domain rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution"/>
         <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"/>
         <rdfs:label xml:lang="en">Legislative History</rdfs:label>
         <rdfs:comment xml:lang="en">Legislative/history narrative for a resolution, typically derived from XML /document/meta/history/text. If source content includes HTML markup, the intended RDF literal is plain text with tags removed.</rdfs:comment>
@@ -835,10 +835,10 @@
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#number -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#number -->
 
-    <owl:DatatypeProperty rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#number">
-        <rdfs:domain rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution"/>
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#number">
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution"/>
         <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"/>
         <rdfs:label xml:lang="en">Number</rdfs:label>
         <rdfs:comment xml:lang="en">Resolution identifier/number (e.g., "031-20"), typically sourced from XML /document/num.</rdfs:comment>
@@ -846,28 +846,28 @@
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#publicNote -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#publicNote -->
 
-    <owl:DatatypeProperty rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#publicNote">
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#publicNote">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
-        <rdfs:domain rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution"/>
         <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Public Note</rdfs:label>
     </owl:DatatypeProperty>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#url -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#url -->
 
-    <owl:DatatypeProperty rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#url">
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#url">
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
-                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -898,7 +898,7 @@
     <!-- http://purl.org/dc/terms/Jurisdiction -->
 
     <owl:Class rdf:about="http://purl.org/dc/terms/Jurisdiction">
-        <owl:equivalentClass rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
+        <owl:equivalentClass rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
         <rdfs:subClassOf rdf:resource="http://purl.org/dc/terms/LocationPeriodOrJurisdiction"/>
     </owl:Class>
     
@@ -940,83 +940,83 @@
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Article -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Article -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Article">
-        <rdfs:subClassOf rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart"/>
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Article">
+        <rdfs:subClassOf rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart"/>
     </owl:Class>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Attachment -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Attachment -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Attachment">
-        <rdfs:subClassOf rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Attachment">
+        <rdfs:subClassOf rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
     </owl:Class>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Chapter -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Chapter -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Chapter">
-        <rdfs:subClassOf rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart"/>
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Chapter">
+        <rdfs:subClassOf rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart"/>
     </owl:Class>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Charter -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Charter -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Charter">
-        <rdfs:subClassOf rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Charter">
+        <rdfs:subClassOf rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
     </owl:Class>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Code -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Code -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Code">
-        <rdfs:subClassOf rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Code">
+        <rdfs:subClassOf rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
     </owl:Class>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Constitution -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Constitution -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Constitution">
-        <rdfs:subClassOf rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Constitution">
+        <rdfs:subClassOf rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
     </owl:Class>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document">
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document">
         <rdfs:subClassOf rdf:resource="http://purl.org/dc/terms/BibliographicResource"/>
         <rdfs:comment xml:lang="en">A legal document as an intellectual entity (e.g., a constitution, charter, code, ordinance, or resolution). Version-specific snapshot metadata is typically modeled using DocumentVersion.</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart">
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart">
         <rdfs:subClassOf rdf:resource="http://purl.org/dc/terms/BibliographicResource"/>
     </owl:Class>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion">
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion">
         <rdfs:subClassOf rdf:resource="http://purl.org/dc/terms/BibliographicResource"/>
         <rdfs:comment xml:lang="en">A time-specific snapshot of a Document, typically the unit of ingest and archival description. Version-level properties (e.g., dateCurrentThrough, lastCodifiedDocument, publication/date-specific URLs) are expected to remain stable for a given version.</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction">
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction">
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.org/dc/terms/title"/>
@@ -1027,65 +1027,65 @@
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Ordinance -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Ordinance -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Ordinance">
-        <rdfs:subClassOf rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Ordinance">
+        <rdfs:subClassOf rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
     </owl:Class>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication">
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication">
         <rdfs:comment xml:lang="en">A published snapshot/build of a library at a particular publication/build date. In OLL permalinks, a complete historical reference may require both the publication/build date (when the historical record was rebuilt) and a display/view date (the "as of" date being viewed), because jurisdictions may change the past.</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution">
-        <rdfs:subClassOf rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution">
+        <rdfs:subClassOf rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
         <rdfs:comment xml:lang="en">Resolution title practices vary by jurisdiction. dcterms:title is often constructed to match the published HTML title.</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Section -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Section -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Section">
-        <rdfs:subClassOf rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart"/>
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Section">
+        <rdfs:subClassOf rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart"/>
     </owl:Class>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument">
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument">
         <rdfs:subClassOf rdf:resource="http://purl.org/dc/terms/BibliographicResource"/>
     </owl:Class>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Subchapter -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Subchapter -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Subchapter">
-        <rdfs:subClassOf rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart"/>
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Subchapter">
+        <rdfs:subClassOf rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart"/>
     </owl:Class>
     
 
 
-    <!-- http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Title -->
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Title -->
 
-    <owl:Class rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Title">
-        <rdfs:subClassOf rdf:resource="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart"/>
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Title">
+        <rdfs:subClassOf rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentPart"/>
     </owl:Class>
     
 
@@ -1101,30 +1101,30 @@
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Article"/>
-            <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Chapter"/>
-            <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Section"/>
-            <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Subchapter"/>
-            <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Title"/>
+            <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Article"/>
+            <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Chapter"/>
+            <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Section"/>
+            <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Subchapter"/>
+            <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Title"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Attachment"/>
-            <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Charter"/>
-            <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Code"/>
-            <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Constitution"/>
-            <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Ordinance"/>
-            <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution"/>
+            <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Attachment"/>
+            <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Charter"/>
+            <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Code"/>
+            <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Constitution"/>
+            <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Ordinance"/>
+            <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
-            <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
-            <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
+            <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+            <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
+            <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
         </owl:members>
     </rdf:Description>
 </rdf:RDF>

--- a/us/ngo/oll/_ontology/v0.1/ontology.owl
+++ b/us/ngo/oll/_ontology/v0.1/ontology.owl
@@ -30,9 +30,7 @@
     
 
 
-    <!-- http://www.w3.org/2002/07/owl#isPartOf -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2002/07/owl#isPartOf"/>
+    <!-- (Removed) owl:isPartOf was previously declared here, but it is not a standard OWL vocabulary term. -->
     
 
 
@@ -395,9 +393,7 @@
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/issued -->
-
-    <owl:DatatypeProperty rdf:about="http://purl.org/dc/elements/1.1/issued"/>
+    <!-- (Removed) dc:issued is not a DC Elements 1.1 term; use dcterms:issued instead. -->
     
 
 
@@ -407,9 +403,7 @@
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/modified -->
-
-    <owl:DatatypeProperty rdf:about="http://purl.org/dc/elements/1.1/modified"/>
+    <!-- (Removed) dc:modified is not a DC Elements 1.1 term; use dcterms:modified instead. -->
     
 
 

--- a/us/ngo/oll/_ontology/v0.1/ontology.owl
+++ b/us/ngo/oll/_ontology/v0.1/ontology.owl
@@ -307,7 +307,14 @@
 
     <owl:ObjectProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasPublication">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#PublicationVersion"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
         <rdfs:label xml:lang="en">Has Publication</rdfs:label>
     </owl:ObjectProperty>
@@ -847,21 +854,46 @@
 
     <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#codifiedDate">
         <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/date"/>
-        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#date"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#PublicationVersion"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#CollectionVersion"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:label xml:lang="en">Codified Date</rdfs:label>
-        <rdfs:comment xml:lang="en">The "as-of"/view date associated with a particular DocumentVersion in the published permalink structure (often referred to as version date and the value used in /_date/YYYY-MM-DD/).</rdfs:comment>
+        <rdfs:comment xml:lang="en">The "as-of"/view date associated with a particular DocumentVersion (and related versioned resources) in the published permalink structure (often referred to as version date and the value used in /_date/YYYY-MM-DD/). Intended lexical form is YYYY-MM-DD.</rdfs:comment>
     </owl:DatatypeProperty>
 
 
     <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#buildTrigger -->
 
-    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#buildTrigger">
-        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/description"/>
+    <owl:ObjectProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#buildTrigger">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#PublicationVersion"/>
         <rdfs:range rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
         <rdfs:label xml:lang="en">Build Trigger</rdfs:label>
-        <rdfs:comment xml:lang="en">Reason a particular version entry exists (e.g., subject document became effective). Only exists for documents that caused the build on this codified date.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Points to the DocumentVersion resource(s) that triggered a publication version build (e.g., created, effective, applicable, expired), when build trigger data is available.</rdfs:comment>
+    </owl:ObjectProperty>
+
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#name -->
+
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#name">
+        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/title"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Collection"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#CollectionVersion"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en">Name</rdfs:label>
+        <rdfs:comment xml:lang="en">Human-readable name for a collection in the library hierarchy.</rdfs:comment>
     </owl:DatatypeProperty>
 
     <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#buildReason -->
@@ -917,6 +949,14 @@
 
     <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#libraryMaterializedPath">
         <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/identifier"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Collection"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#CollectionVersion"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:label xml:lang="en">Library Materialized Path</rdfs:label>
         <rdfs:comment xml:lang="en">A materialized path string representing the resource's position in the library hierarchy.</rdfs:comment>

--- a/us/ngo/oll/_ontology/v0.1/ontology.owl
+++ b/us/ngo/oll/_ontology/v0.1/ontology.owl
@@ -354,7 +354,14 @@
 
     <owl:ObjectProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasChanges">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
+                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#CollectionVersion"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag"/>
         <rdfs:label xml:lang="en">Has Changes</rdfs:label>
         <rdfs:comment xml:lang="en">Links a DocumentVersion to a resource (often an rdf:Bag) enumerating changed elements/resources for that build.</rdfs:comment>
@@ -1140,7 +1147,17 @@
     
     <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Collection -->
 
-    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Collection"/>
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Collection">
+        <rdfs:subClassOf rdf:resource="http://purl.org/dc/terms/BibliographicResource"/>
+        <rdfs:comment xml:lang="en">A navigational collection node in the library hierarchy (e.g., a resolutions collection by year).</rdfs:comment>
+    </owl:Class>
+
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#CollectionVersion -->
+
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#CollectionVersion">
+        <rdfs:subClassOf rdf:resource="http://purl.org/dc/terms/BibliographicResource"/>
+        <rdfs:comment xml:lang="en">A time-specific snapshot of a Collection (a dated view of the collection within a publication/codified date).</rdfs:comment>
+    </owl:Class>
     
 
     <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Constitution -->

--- a/us/ngo/oll/_ontology/v0.1/ontology.owl
+++ b/us/ngo/oll/_ontology/v0.1/ontology.owl
@@ -373,7 +373,7 @@
     <!-- http://purl.org/dc/elements/1.1/creator -->
 
     <owl:DatatypeProperty rdf:about="http://purl.org/dc/elements/1.1/creator">
-        <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
     </owl:DatatypeProperty>
     
 
@@ -444,7 +444,7 @@
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
-        <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
     </owl:DatatypeProperty>
     
 
@@ -452,7 +452,7 @@
     <!-- http://purl.org/dc/elements/1.1/subject -->
 
     <owl:DatatypeProperty rdf:about="http://purl.org/dc/elements/1.1/subject">
-        <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
     </owl:DatatypeProperty>
     
 
@@ -471,7 +471,7 @@
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
-        <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
     </owl:DatatypeProperty>
     
 
@@ -752,7 +752,7 @@
     <!-- http://purl.org/dc/terms/subject -->
 
     <owl:DatatypeProperty rdf:about="http://purl.org/dc/terms/subject">
-        <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
     </owl:DatatypeProperty>
     
 
@@ -762,7 +762,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.org/dc/terms/tableOfContents">
         <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/description"/>
         <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Code"/>
-        <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
     </owl:DatatypeProperty>
     
 
@@ -906,7 +906,7 @@
     <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#history">
         <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/description"/>
         <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution"/>
-        <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:label xml:lang="en">Legislative History</rdfs:label>
         <rdfs:comment xml:lang="en">Legislative/history narrative for a resolution, typically derived from XML /document/meta/history/text. If source content includes HTML markup, the intended RDF literal is plain text with tags removed.</rdfs:comment>
     </owl:DatatypeProperty>
@@ -917,7 +917,7 @@
 
     <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#number">
         <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution"/>
-        <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:label xml:lang="en">Number</rdfs:label>
         <rdfs:comment xml:lang="en">Resolution identifier/number (e.g., "031-20"), typically sourced from XML /document/num.</rdfs:comment>
     </owl:DatatypeProperty>
@@ -929,8 +929,8 @@
     <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#publicNote">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution"/>
-        <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Public Note</rdfs:label>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en">Public Note</rdfs:label>
     </owl:DatatypeProperty>
     
 

--- a/us/ngo/oll/_ontology/v0.1/ontology.owl
+++ b/us/ngo/oll/_ontology/v0.1/ontology.owl
@@ -766,7 +766,7 @@
         <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/description"/>
         <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Code"/>
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <rdfs:comment xml:lang="en">Free-text table of contents / outline as emitted by the build pipeline. In law-rdf this may appear on codes and constitutions.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Free-text table of contents / outline. In law-rdf this may appear on codes and constitutions.</rdfs:comment>
     </owl:DatatypeProperty>
     
 
@@ -862,7 +862,7 @@
         <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:label xml:lang="en">Document Id</rdfs:label>
-        <rdfs:comment xml:lang="en">Internal identifier/label for the document/version as emitted by the build pipeline.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Internal identifier/label for the document/version.</rdfs:comment>
     </owl:DatatypeProperty>
 
 
@@ -892,7 +892,7 @@
         <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/type"/>
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:label xml:lang="en">PTag</rdfs:label>
-        <rdfs:comment xml:lang="en">Pipeline-emitted tag describing the kind of element (e.g., document, section, container).</rdfs:comment>
+        <rdfs:comment xml:lang="en">Tag describing the kind of element (e.g., document, section, container).</rdfs:comment>
     </owl:DatatypeProperty>
 
 
@@ -902,7 +902,7 @@
         <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/description"/>
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:label xml:lang="en">Status</rdfs:label>
-        <rdfs:comment xml:lang="en">Pipeline-emitted status markers for the resource within a build (repeatable; e.g., added, effective).</rdfs:comment>
+        <rdfs:comment xml:lang="en">Status representing change information of the related cite (e.g., added, effective, removed, changed).</rdfs:comment>
     </owl:DatatypeProperty>
 
     <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#history -->

--- a/us/ngo/oll/_ontology/v0.1/ontology.owl
+++ b/us/ngo/oll/_ontology/v0.1/ontology.owl
@@ -352,6 +352,16 @@
         <rdfs:label xml:lang="en">Has Changes</rdfs:label>
         <rdfs:comment xml:lang="en">Links a DocumentVersion to a resource (often an rdf:Bag) enumerating changed elements/resources for that build.</rdfs:comment>
     </owl:ObjectProperty>
+
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasElements -->
+
+    <owl:ObjectProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasElements">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#CollectionVersion"/>
+        <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq"/>
+        <rdfs:label xml:lang="en">Has Elements</rdfs:label>
+        <rdfs:comment xml:lang="en">Links a CollectionVersion to a sequence of containing headings, subheadings, collections and documents.</rdfs:comment>
+    </owl:ObjectProperty>
     
 
 
@@ -840,9 +850,19 @@
         <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#date"/>
         <rdfs:label xml:lang="en">Codified Date</rdfs:label>
-        <rdfs:comment xml:lang="en">The "as-of"/view date associated with a particular DocumentVersion in the published permalink structure (often the value used in /_date/YYYY-MM-DD/).</rdfs:comment>
+        <rdfs:comment xml:lang="en">The "as-of"/view date associated with a particular DocumentVersion in the published permalink structure (often referred to as version date and the value used in /_date/YYYY-MM-DD/).</rdfs:comment>
     </owl:DatatypeProperty>
 
+
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#buildTrigger -->
+
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#buildTrigger">
+        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/description"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#PublicationVersion"/>
+        <rdfs:range rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
+        <rdfs:label xml:lang="en">Build Trigger</rdfs:label>
+        <rdfs:comment xml:lang="en">Reason a particular version entry exists (e.g., subject document became effective). Only exists for documents that caused the build on this codified date.</rdfs:comment>
+    </owl:DatatypeProperty>
 
     <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#buildReason -->
 
@@ -851,9 +871,17 @@
         <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:label xml:lang="en">Build Reason</rdfs:label>
-        <rdfs:comment xml:lang="en">Reason a particular build/version entry exists or was emitted (e.g., effective).</rdfs:comment>
+        <rdfs:comment xml:lang="en">Reason a particular version entry exists (e.g., subject document became effective). Only exists for documents that caused the build on this codified date.</rdfs:comment>
     </owl:DatatypeProperty>
 
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#reason -->
+
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#reason">
+        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/description"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en">Reason</rdfs:label>
+        <rdfs:comment xml:lang="en">Reason why a particular citeable element changed.</rdfs:comment>
+    </owl:DatatypeProperty>
 
     <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#docId -->
 
@@ -872,7 +900,7 @@
         <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/identifier"/>
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:label xml:lang="en">Cite</rdfs:label>
-        <rdfs:comment xml:lang="en">Citation/locator text used within a document hierarchy (e.g., "ARTICLE I", "Section 1", or an internal short cite token).</rdfs:comment>
+        <rdfs:comment xml:lang="en">Citation text used within a document hierarchy (e.g., "ARTICLE I", "Section 1", or an internal short cite token).</rdfs:comment>
     </owl:DatatypeProperty>
 
 
@@ -883,6 +911,15 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:label xml:lang="en">Document Materialized Path</rdfs:label>
         <rdfs:comment xml:lang="en">A materialized path string representing the resource's position in the document hierarchy.</rdfs:comment>
+    </owl:DatatypeProperty>
+
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#libraryMaterializedPath -->
+
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#libraryMaterializedPath">
+        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/identifier"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en">Library Materialized Path</rdfs:label>
+        <rdfs:comment xml:lang="en">A materialized path string representing the resource's position in the library hierarchy.</rdfs:comment>
     </owl:DatatypeProperty>
 
 
@@ -1061,7 +1098,10 @@
         <rdfs:subClassOf rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
     </owl:Class>
     
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Collection -->
 
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Collection"/>
+    
 
     <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Constitution -->
 
@@ -1127,9 +1167,15 @@
     <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication -->
 
     <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication">
-        <rdfs:comment xml:lang="en">A published snapshot/build of a library at a particular publication/build date. In OLL permalinks, a complete historical reference may require both the publication/build date (when the historical record was rebuilt) and a display/view date (the "as of" date being viewed), because jurisdictions may change the past.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A published build of a library at a particular publication/build date. In OLL permalinks, a complete historical reference may require both the publication/build date (when the historical record was rebuilt) and a display/view date (the "as of" date being viewed), because jurisdictions may change the past.</rdfs:comment>
     </owl:Class>
     
+    
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#PublicationVersion -->
+
+    <owl:Class rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#PublicationVersion">
+        <rdfs:comment xml:lang="en">A published build of a library at a particular publication/build date and version date (display/view date).</rdfs:comment>
+    </owl:Class>
 
 
     <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Resolution -->

--- a/us/ngo/oll/_ontology/v0.1/ontology.owl
+++ b/us/ngo/oll/_ontology/v0.1/ontology.owl
@@ -2,7 +2,7 @@
 <rdf:RDF xmlns="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#"
      xml:base="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
-     xmlns:oll="http://open.law/ontologies/oll.owl#"
+     xmlns:oll="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
@@ -338,6 +338,17 @@
         <rdfs:range rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
         <rdfs:label xml:lang="en">Last Codified Document</rdfs:label>
         <rdfs:comment xml:lang="en">Points to the document that last codified/modified this DocumentVersion; typically sourced from XML /document/recency/doc. In RDF instances, the object IRI should identify the cited HTML/PDF resource, not an RDF description document.</rdfs:comment>
+    </owl:ObjectProperty>
+
+
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasChanges -->
+
+    <owl:ObjectProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#hasChanges">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
+        <rdfs:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag"/>
+        <rdfs:label xml:lang="en">Has Changes</rdfs:label>
+        <rdfs:comment xml:lang="en">Links a DocumentVersion to a resource (often an rdf:Bag) enumerating changed elements/resources for that build.</rdfs:comment>
     </owl:ObjectProperty>
     
 
@@ -817,6 +828,79 @@
         <rdfs:label xml:lang="en">Date Effective</rdfs:label>
     </owl:DatatypeProperty>
 
+
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#codifiedDate -->
+
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#codifiedDate">
+        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/date"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#date"/>
+        <rdfs:label xml:lang="en">Codified Date</rdfs:label>
+        <rdfs:comment xml:lang="en">The "as-of"/view date associated with a particular DocumentVersion in the published permalink structure (often the value used in /_date/YYYY-MM-DD/).</rdfs:comment>
+    </owl:DatatypeProperty>
+
+
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#buildReason -->
+
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#buildReason">
+        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/description"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en">Build Reason</rdfs:label>
+        <rdfs:comment xml:lang="en">Reason a particular build/version entry exists or was emitted (e.g., effective).</rdfs:comment>
+    </owl:DatatypeProperty>
+
+
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#docId -->
+
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#docId">
+        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/identifier"/>
+        <rdfs:domain rdf:resource="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#DocumentVersion"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en">Document Id</rdfs:label>
+        <rdfs:comment xml:lang="en">Internal identifier/label for the document/version as emitted by the build pipeline.</rdfs:comment>
+    </owl:DatatypeProperty>
+
+
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#cite -->
+
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#cite">
+        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/identifier"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en">Cite</rdfs:label>
+        <rdfs:comment xml:lang="en">Citation/locator text used within a document hierarchy (e.g., "ARTICLE I", "Section 1", or an internal short cite token).</rdfs:comment>
+    </owl:DatatypeProperty>
+
+
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#documentMaterializedPath -->
+
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#documentMaterializedPath">
+        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/identifier"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en">Document Materialized Path</rdfs:label>
+        <rdfs:comment xml:lang="en">A materialized path string representing the resource's position in the document hierarchy.</rdfs:comment>
+    </owl:DatatypeProperty>
+
+
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#ptag -->
+
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#ptag">
+        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/type"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en">PTag</rdfs:label>
+        <rdfs:comment xml:lang="en">Pipeline-emitted tag describing the kind of element (e.g., document, section, container).</rdfs:comment>
+    </owl:DatatypeProperty>
+
+
+    <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#status -->
+
+    <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#status">
+        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/description"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en">Status</rdfs:label>
+        <rdfs:comment xml:lang="en">Pipeline-emitted status markers for the resource within a build (repeatable; e.g., added, effective).</rdfs:comment>
+    </owl:DatatypeProperty>
+
     <!-- https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#history -->
 
     <owl:DatatypeProperty rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#history">
@@ -857,17 +941,18 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
-                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
-                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
-                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
-                    <rdf:Description rdf:about="https://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
+                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Document"/>
+                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Jurisdiction"/>
+                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Library"/>
+                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#Publication"/>
+                    <rdf:Description rdf:about="http://open.law/us/ngo/oll/_ontology/v0.1/ontology.owl#SourceDocument"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:label xml:lang="en">URL</rdfs:label>
-        <rdfs:comment xml:lang="en">Permalink/canonical URL for the described resource (often matching rdf:about). In the OLL publication model, stable permalinks may include both a publication/build date component (/_publication/YYYY-MM-DD[-NN]/) and a display/view date component (/_date/YYYY-MM-DD/).</rdfs:comment>
+        <rdfs:comment xml:lang="en">Permalink/canonical URL or path for the described resource (often matching rdf:about). In law-rdf, this is commonly emitted as a relative path (e.g., "/us/ngo/..."), and may appear on DocumentVersion and document-part resources.</rdfs:comment>
+        <rdfs:comment xml:lang="en">In the OLL publication model, stable permalinks may include both a publication/build date component (/_publication/YYYY-MM-DD[-NN]/) and a display/view date component (/_date/YYYY-MM-DD/).</rdfs:comment>
     </owl:DatatypeProperty>
     
 


### PR DESCRIPTION
- Switched the ontology’s canonical OLL namespace from 'http://open.law/...' to 'https://open.law/...' so it matches the IRIs actually used in `law-rdf`.
- Removed nonstandard/incorrect vocabulary declarations: dropped `owl:isPartOf` and removed `dc:issued/dc:modified` (use `dcterms:issued/dcterms:modified`).
- Eliminated OWL DL-breaking “dual-typed” DC/DCTERMS predicates (no more properties declared as both owl:ObjectProperty and owl:DatatypeProperty).
- Relaxed risky DC/DCTERMS constraints that don’t match real data (e.g., removed narrow dcterms:references domain/range; relaxed dcterms:available and dcterms:tableOfContents domains).
- Added missing OLL terms that appear in law-rdf output (e.g., `oll:cite`, `oll:codifiedDate`, `oll:docId`, `oll:documentMaterializedPath`, `oll:ptag`, `oll:status`, `oll:buildReason`, `oll:hasChanges`) with labels/comments.
- Normalized literal handling by replacing `rdf:PlainLiteral` ranges with `rdfs:Literal` and fixed `oll:publicNote`’s invalid typed `rdfs:label`.
- Kept/expanded prior documentation work (`hasFormat` vs `references`, `rdf:about` guidance, publication/date semantics) while making the ontology consistent with current emitted RDF.